### PR TITLE
Clean up message API a bit

### DIFF
--- a/pkg/zoom/message_types.go
+++ b/pkg/zoom/message_types.go
@@ -10,6 +10,9 @@ import (
 WEBSOCKET MESSAGE TYPES
 */
 
+type Message interface {
+}
+
 type GenericZoomMessage struct {
 	Body json.RawMessage `json:"body,omitempty"`
 	Evt  int             `json:"evt"`

--- a/pkg/zoom/websocket.go
+++ b/pkg/zoom/websocket.go
@@ -120,7 +120,7 @@ func (session *ZoomSession) GetWebsocketUrl(meetingInfo *MeetingInfo, wasInWaiti
 	}).String(), nil
 }
 
-type onMessage func(session *ZoomSession, message *GenericZoomMessage) error
+type onMessage func(session *ZoomSession, message Message) error
 
 func (session *ZoomSession) MakeWebsocketConnection(websocketUrl string, cookieString string, onMessageFunction onMessage) error {
 	websocketHeaders := http.Header{}
@@ -205,7 +205,13 @@ func (session *ZoomSession) MakeWebsocketConnection(websocketUrl string, cookieS
 
 			// dont run the user defined functions in the waiting room
 			if !wasInWaitingRoom {
-				err = onMessageFunction(session, message)
+				// convert generic json message to go type
+				m, err := GetMessageBody(message)
+				if err != nil {
+					log.Printf("Decoding message failed: %+v", err)
+					continue
+				}
+				err = onMessageFunction(session, m)
 				if err != nil {
 					log.Printf("User defined function failed: %+v", err)
 				}


### PR DESCRIPTION
This PR changes the API of `session.MakeWebsocketConnection` so that the caller can type-switch on the message, rather than switching on the `Evt` field and decoding the JSON themselves.

I also tried to clean up the mapping from `Evt` to Go type via a bit of reflection, but I wasn't able to test it locally, so...fingers crossed it works at runtime. 😬 